### PR TITLE
Add ISO timezones

### DIFF
--- a/gldcore/tzinfo.txt
+++ b/gldcore/tzinfo.txt
@@ -109,6 +109,7 @@ EST5 ; Eastern no DST
 CST6 ; Central no DST
 MST7 ; Mountain no DST
  US/AZ/Phoenix
+ America/Phoenix
 PST8 ; Pacific no DST
 AST9 ; Alaska no DST
 HST10; Hawaii no DST
@@ -140,6 +141,7 @@ PST+8PDT,M4.5.0/02:00,M10.5.0/02:00 ; Pacific, DST 2am last Sun/Apr to last Sun/
  US/CA/San Francisco
  US/OR/Portland
  US/WA/Seattle
+ America/Los_Angeles
 AST+9ADT,M4.5.0/02:00,M10.5.0/02:00 ; Alaska DST 2am last Sun/Apr to last Sun/Oct
  US/AK/Anchorage
 HST+10HDT,M4.5.0/02:00,M10.5.0/02:00 ; Hawaii DST 2am last Sun/Apr to last Sun/Oct


### PR DESCRIPTION
The goal of this PR is to add support for ISO timezone locales, e.g., `America/Los Angeles` instead of `US/CA/Los Angeles`.